### PR TITLE
Fixing Espresso runs on build matrix

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -176,5 +176,4 @@ jobs:
         uses: reactivecircus/android-emulator-runner@v2.11.0
         with:
           api-level: ${{ matrix.android_sdk }}
-          arch: x86_64
           script: ./scripts/espresso-run.sh

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -161,7 +161,7 @@ jobs:
     strategy:
       fail-fast: true
       matrix:
-        android_sdk: [23, 25, 28, 29]
+        android_sdk: [25, 28, 29]
 
     runs-on: macOS-latest
     needs: [assemble_apk, espresso_prepare]

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -164,7 +164,7 @@ jobs:
         android_sdk: [23, 24, 25, 26, 27, 28, 29]
 
     runs-on: macOS-latest
-    needs: assemble_apk
+    needs: [assemble_apk, espresso_prepare]
     steps:
 
       - name: Project Checkout

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -161,7 +161,7 @@ jobs:
     strategy:
       fail-fast: true
       matrix:
-        android_sdk: [26, 27, 28, 29]
+        android_sdk: [27, 28, 29]
 
     runs-on: macOS-latest
     needs: [assemble_apk, espresso_prepare]
@@ -178,4 +178,11 @@ jobs:
           api-level: ${{ matrix.android_sdk }}
           arch: x86_64
           script: ./scripts/espresso-run.sh
+
+      - name: Archive instrumentation results
+        if: always()
+        uses: actions/upload-artifact@v2.1.4
+        with:
+          name: instrumentation-log
+          path: adb-test.log
 

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -161,7 +161,7 @@ jobs:
     strategy:
       fail-fast: true
       matrix:
-        android_sdk: [29]
+        android_sdk: [27, 28, 29]
 
     runs-on: macOS-latest
     needs: [assemble_apk, espresso_prepare]

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -161,7 +161,7 @@ jobs:
     strategy:
       fail-fast: true
       matrix:
-        android_sdk: [29, 30]
+        android_sdk: [29]
 
     runs-on: macOS-latest
     needs: [assemble_apk, espresso_prepare]

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -161,7 +161,7 @@ jobs:
     strategy:
       fail-fast: true
       matrix:
-        android_sdk: [27, 28, 29]
+        android_sdk: [23, 25, 28, 29]
 
     runs-on: macOS-latest
     needs: [assemble_apk, espresso_prepare]

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -161,7 +161,7 @@ jobs:
     strategy:
       fail-fast: true
       matrix:
-        android_sdk: [27, 28, 29]
+        android_sdk: [29, 30]
 
     runs-on: macOS-latest
     needs: [assemble_apk, espresso_prepare]

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -178,11 +178,3 @@ jobs:
           api-level: ${{ matrix.android_sdk }}
           arch: x86_64
           script: ./scripts/espresso-run.sh
-
-      - name: Archive instrumentation results
-        if: always()
-        uses: actions/upload-artifact@v2.1.4
-        with:
-          name: instrumentation-logs
-          path: instrumentation-outputs
-

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -161,7 +161,7 @@ jobs:
     strategy:
       fail-fast: true
       matrix:
-        android_sdk: [23, 24, 25, 26, 27, 28, 29]
+        android_sdk: [26, 27, 28, 29]
 
     runs-on: macOS-latest
     needs: [assemble_apk, espresso_prepare]

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -183,6 +183,6 @@ jobs:
         if: always()
         uses: actions/upload-artifact@v2.1.4
         with:
-          name: instrumentation-log
-          path: adb-test.log
+          name: instrumentation-logs
+          path: instrumentation-outputs
 

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -92,6 +92,7 @@ android {
 
 dependencies {
     coreLibraryDesugaring(Libraries.coreLibrariesDesugaring)
+    implementation(Libraries.ticktock)
 
     implementation(project(":platform:logger"))
     implementation(project(":platform:domain"))

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -77,7 +77,6 @@ android {
     compileOptions {
         sourceCompatibility = JavaVersion.VERSION_1_8
         targetCompatibility = JavaVersion.VERSION_1_8
-        coreLibraryDesugaringEnabled = true
     }
 
     tasks.withType<KotlinCompile> {
@@ -91,9 +90,6 @@ android {
 }
 
 dependencies {
-    coreLibraryDesugaring(Libraries.coreLibrariesDesugaring)
-    implementation(Libraries.ticktock)
-
     implementation(project(":platform:logger"))
     implementation(project(":platform:domain"))
     implementation(project(":platform:rest-chucknorris"))
@@ -124,7 +120,7 @@ dependencies {
     androidTestImplementation(Libraries.androidTestCore)
     androidTestImplementation(Libraries.espressoCore)
     androidTestImplementation(Libraries.barista)
-    androidTestImplementation(Libraries.assertj)
+    androidTestImplementation(Libraries.assertjJava7)
     androidTestImplementation(Libraries.mockWebServer)
 }
 

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -77,6 +77,7 @@ android {
     compileOptions {
         sourceCompatibility = JavaVersion.VERSION_1_8
         targetCompatibility = JavaVersion.VERSION_1_8
+        coreLibraryDesugaringEnabled = true
     }
 
     tasks.withType<KotlinCompile> {
@@ -90,6 +91,7 @@ android {
 }
 
 dependencies {
+    coreLibraryDesugaring(Libraries.coreLibrariesDesugaring)
 
     implementation(project(":platform:logger"))
     implementation(project(":platform:domain"))

--- a/app/src/androidTest/java/io/dotanuki/demos/norris/util/ChipGroupContentAssertion.kt
+++ b/app/src/androidTest/java/io/dotanuki/demos/norris/util/ChipGroupContentAssertion.kt
@@ -6,7 +6,7 @@ import androidx.test.espresso.NoMatchingViewException
 import androidx.test.espresso.ViewAssertion
 import com.google.android.material.chip.Chip
 import com.google.android.material.chip.ChipGroup
-import org.assertj.core.api.Assertions.assertThat
+import org.assertj.core.api.Java6Assertions.assertThat
 
 class ChipGroupContentAssertion(private val chips: List<String>) : ViewAssertion {
 

--- a/buildSrc/src/main/kotlin/BuildPlugins.kt
+++ b/buildSrc/src/main/kotlin/BuildPlugins.kt
@@ -34,6 +34,6 @@ object BuildPlugins {
         const val ktlint = "9.4.0"
         const val detekt = "1.12.0"
         const val jacocoUnified = "0.16.0"
-        const val keeper = "0.6.0"
+        const val keeper = "0.7.0"
     }
 }

--- a/buildSrc/src/main/kotlin/Libraries.kt
+++ b/buildSrc/src/main/kotlin/Libraries.kt
@@ -27,6 +27,7 @@ object Libraries {
     const val coroutinesDebug = "org.jetbrains.kotlinx:kotlinx-coroutines-debug:${Versions.coroutines}"
 
     const val kodein = "org.kodein.di:kodein-di-jvm:${Versions.kodein}"
+    const val coreLibrariesDesugaring = "com.android.tools:desugar_jdk_libs:1.0.9"
 
     const val jUnit = "junit:junit:${Versions.junit}"
     const val assertj = "org.assertj:assertj-core:${Versions.assertj}"

--- a/buildSrc/src/main/kotlin/Libraries.kt
+++ b/buildSrc/src/main/kotlin/Libraries.kt
@@ -27,11 +27,10 @@ object Libraries {
     const val coroutinesDebug = "org.jetbrains.kotlinx:kotlinx-coroutines-debug:${Versions.coroutines}"
 
     const val kodein = "org.kodein.di:kodein-di-jvm:${Versions.kodein}"
-    const val coreLibrariesDesugaring = "com.android.tools:desugar_jdk_libs:1.0.9"
-    const val ticktock = "dev.zacsweers.ticktock:ticktock-android-tzdb:0.1.1"
 
     const val jUnit = "junit:junit:${Versions.junit}"
     const val assertj = "org.assertj:assertj-core:${Versions.assertj}"
+    const val assertjJava7 = "org.assertj:assertj-core:2.9.1"
     const val burster = "com.github.ubiratansoares:burster:${Versions.burster}"
     const val turbine = "app.cash.turbine:turbine:${Versions.turbine}"
     const val barista = "com.schibsted.spain:barista:${Versions.barista}"

--- a/buildSrc/src/main/kotlin/Libraries.kt
+++ b/buildSrc/src/main/kotlin/Libraries.kt
@@ -28,6 +28,7 @@ object Libraries {
 
     const val kodein = "org.kodein.di:kodein-di-jvm:${Versions.kodein}"
     const val coreLibrariesDesugaring = "com.android.tools:desugar_jdk_libs:1.0.9"
+    const val ticktock = "dev.zacsweers.ticktock:ticktock-android-tzdb:0.1.1"
 
     const val jUnit = "junit:junit:${Versions.junit}"
     const val assertj = "org.assertj:assertj-core:${Versions.assertj}"

--- a/scripts/espresso-run.sh
+++ b/scripts/espresso-run.sh
@@ -9,8 +9,7 @@ find  . -name "*.apk" -print -exec adb install {} \;
 
 echo "\n🔥 Running instrumentation"
 
-RUNNER="io.dotanuki.demos.norris.test/androidx.test.runner.AndroidJUnitRunner"
-adb shell 'am instrument -w $RUNNER; echo $?' | grep 'FAILURES'
+adb shell 'am instrument -w io.dotanuki.demos.norris.test/androidx.test.runner.AndroidJUnitRunner; echo $?' | grep 'FAILURES'
 
 if [ $? -eq 0 ]; then
   echo "\n🔥 Instrumentation test execution failed! Aborting\n"

--- a/scripts/espresso-run.sh
+++ b/scripts/espresso-run.sh
@@ -9,11 +9,17 @@ find  . -name "*.apk" -print -exec adb install {} \;
 
 echo "\n🔥 Running instrumentation"
 RUNNER="io.dotanuki.demos.norris.test/androidx.test.runner.AndroidJUnitRunner"
-adb shell "am instrument -w $RUNNER; echo $?" | grep "FAILURES" # https://stackoverflow.com/a/58452689/1880882
+adb shell am instrument -w -r $RUNNER |& tee adb-test.log
 
 if [ $? -eq 0 ]; then
     echo "\n🔥 Instrumentation test execution failed! Aborting\n"
     exit 1
+fi
+
+cat adb-test.log | grep "INSTRUMENTATION_STATUS: stack=" | grep -v "org.junit.AssumptionViolatedException"
+if [ $? -eq 0 ]; then
+  echo "Test failure found"
+  exit 1
 fi
 
 echo "\n🔥 Instrumentation tests ran with success!\n"

--- a/scripts/espresso-run.sh
+++ b/scripts/espresso-run.sh
@@ -9,4 +9,11 @@ find  . -name "*.apk" -print -exec adb install {} \;
 
 echo "\n🔥 Running instrumentation"
 RUNNER="io.dotanuki.demos.norris.test/androidx.test.runner.AndroidJUnitRunner"
-adb shell "am instrument -w $RUNNER; echo $?" # https://stackoverflow.com/a/58452689/1880882
+adb shell "am instrument -w $RUNNER; echo $?" | grep "FAILURES" # https://stackoverflow.com/a/58452689/1880882
+
+if [ $? -eq 0 ]; then
+    echo "Instrumentation test execution failed"
+    exit 1
+fi
+
+exit 0

--- a/scripts/espresso-run.sh
+++ b/scripts/espresso-run.sh
@@ -9,15 +9,16 @@ find  . -name "*.apk" -print -exec adb install {} \;
 
 echo "\n🔥 Running instrumentation"
 
-TEST_RUNNER="io.dotanuki.demos.norris.test/androidx.test.runner.AndroidJUnitRunner"
-adb shell am instrument -w $TEST_RUNNER
+EXECUTION=`adb shell am instrument -w io.dotanuki.demos.norris.test/androidx.test.runner.AndroidJUnitRunner`
 
-# FAILURES=`cat execution.log | grep FAILURES`
+echo $EXECUTION
 
-# if [ ! -z "$FAILURES" ] then
-#   echo "\n🔥 Instrumentation test execution failed!\n"
-#   more execution.log
-#   exit 1
-# fi
+FAILURES=`echo $EXECUTION | grep FAILURES`
+
+if [ ! -z "$FAILURES" ] then
+  echo "\n🔥 Instrumentation test execution failed!\n"
+  more execution.log
+  exit 1
+fi
 
 echo "\n🔥 Instrumentation tests ran with success!\n"

--- a/scripts/espresso-run.sh
+++ b/scripts/espresso-run.sh
@@ -1,6 +1,6 @@
 #! /bin/bash
 
-set -ex
+set -exu
 
 cd ..
 
@@ -11,9 +11,9 @@ echo "\n🔥 Running instrumentation"
 
 EXECUTION=`adb shell am instrument -w io.dotanuki.demos.norris.test/androidx.test.runner.AndroidJUnitRunner`
 
-ERRORS_FOUND=`echo $EXECUTION | grep FAILURES`
+ERRORS_FOUND=`echo $EXECUTION | grep FAILURES | tr -d ' '`
 
-if [[ -n "$ERRORS_FOUND" ]]; then
+if [ -n "$ERRORS_FOUND" ]; then
 	echo "\n🔥 Instrumentation test execution failed!\n"
 	echo $EXECUTION
 	exit 1

--- a/scripts/espresso-run.sh
+++ b/scripts/espresso-run.sh
@@ -9,12 +9,10 @@ find  . -name "*.apk" -print -exec adb install {} \;
 
 echo "\n🔥 Running instrumentation"
 
-mkdir instrumentation-outputs
-
 adb logcat -d &
 
 RUNNER="io.dotanuki.demos.norris.test/androidx.test.runner.AndroidJUnitRunner"
-adb shell am instrument -w $RUNNER | grep "FAILURES"
+adb shell "am instrument -w $RUNNER; echo $?" | grep "FAILURES"
 
 if [ $? -eq 0 ]; then
   echo "\n🔥 Instrumentation test execution failed! Aborting\n"

--- a/scripts/espresso-run.sh
+++ b/scripts/espresso-run.sh
@@ -1,6 +1,6 @@
 #! /bin/bash
 
-set -exu
+set -eu
 
 cd ..
 

--- a/scripts/espresso-run.sh
+++ b/scripts/espresso-run.sh
@@ -12,8 +12,9 @@ RUNNER="io.dotanuki.demos.norris.test/androidx.test.runner.AndroidJUnitRunner"
 adb shell "am instrument -w $RUNNER; echo $?" | grep "FAILURES" # https://stackoverflow.com/a/58452689/1880882
 
 if [ $? -eq 0 ]; then
-    echo "Instrumentation test execution failed"
+    echo "\n🔥 Instrumentation test execution failed! Aborting\n"
     exit 1
 fi
 
+echo "\n🔥 Instrumentation tests ran with success!\n"
 exit 0

--- a/scripts/espresso-run.sh
+++ b/scripts/espresso-run.sh
@@ -11,10 +11,10 @@ echo "\n🔥 Running instrumentation"
 
 mkdir instrumentation-outputs
 
-adb logcat -d | grep 'norris' | tee instrumentation-outputs/log.txt &
+adb logcat &
 
 RUNNER="io.dotanuki.demos.norris.test/androidx.test.runner.AndroidJUnitRunner"
-adb shell am instrument -w -r $RUNNER > instrumentation-outputs/adb-test.log
+adb shell am instrument -w -r $RUNNER | tee instrumentation-outputs/adb-test.log
 
 if [ $? -eq 0 ]; then
     echo "\n🔥 Instrumentation test execution failed! Aborting\n"

--- a/scripts/espresso-run.sh
+++ b/scripts/espresso-run.sh
@@ -9,11 +9,16 @@ find  . -name "*.apk" -print -exec adb install {} \;
 
 echo "\n🔥 Running instrumentation"
 
-adb logcat &
-adb shell 'am instrument -w io.dotanuki.demos.norris.test/androidx.test.runner.AndroidJUnitRunner; echo $?' | grep 'FAILURES'
+TEST_RUNNER="io.dotanuki.demos.norris.test/androidx.test.runner.AndroidJUnitRunner"
+adb shell am instrument -w $ > /sdcard/execution.log
 
-if [ $? -eq 0 ;] then
-  echo "\n🔥 Instrumentation test execution failed! Aborting\n"
+adb pull /sdcard/execution.log .
+
+FAILURES=`cat execution.log | grep FAILURES`
+
+if [ ! -z "$FAILURES" ] then
+  echo "\n🔥 Instrumentation test execution failed!\n"
+  more execution.log
   exit 1
 fi
 

--- a/scripts/espresso-run.sh
+++ b/scripts/espresso-run.sh
@@ -9,7 +9,7 @@ find  . -name "*.apk" -print -exec adb install {} \;
 
 echo "\n🔥 Running instrumentation"
 RUNNER="io.dotanuki.demos.norris.test/androidx.test.runner.AndroidJUnitRunner"
-adb shell am instrument -w -r $RUNNER |& tee adb-test.log
+adb shell am instrument -w -r $RUNNER > adb-test.log
 
 if [ $? -eq 0 ]; then
     echo "\n🔥 Instrumentation test execution failed! Aborting\n"

--- a/scripts/espresso-run.sh
+++ b/scripts/espresso-run.sh
@@ -10,9 +10,7 @@ find  . -name "*.apk" -print -exec adb install {} \;
 echo "\n🔥 Running instrumentation"
 
 TEST_RUNNER="io.dotanuki.demos.norris.test/androidx.test.runner.AndroidJUnitRunner"
-adb shell am instrument -w $ > /sdcard/execution.log
-
-adb pull /sdcard/execution.log .
+adb shell am instrument -w $TEST_RUNNER > execution.log
 
 FAILURES=`cat execution.log | grep FAILURES`
 

--- a/scripts/espresso-run.sh
+++ b/scripts/espresso-run.sh
@@ -8,4 +8,5 @@ echo "🔥 Install the apks...\n"
 find  . -name "*.apk" -print -exec adb install {} \;
 
 echo "\n🔥 Running instrumentation"
-adb shell am instrument -w io.dotanuki.demos.norris.test/androidx.test.runner.AndroidJUnitRunner
+RUNNER="io.dotanuki.demos.norris.test/androidx.test.runner.AndroidJUnitRunner"
+adb shell "am instrument -w $RUNNER; echo $?" # https://stackoverflow.com/a/58452689/1880882

--- a/scripts/espresso-run.sh
+++ b/scripts/espresso-run.sh
@@ -11,21 +11,14 @@ echo "\n🔥 Running instrumentation"
 
 mkdir instrumentation-outputs
 
-adb logcat &
+adb logcat -d | tee instrumentation-outputs/logcat.txt &
 
 RUNNER="io.dotanuki.demos.norris.test/androidx.test.runner.AndroidJUnitRunner"
-adb shell am instrument -w -r $RUNNER | tee instrumentation-outputs/adb-test.log
+adb shell am instrument -w $RUNNER | grep "INSTRUMENTATION_STATUS: stack=" | grep -v "org.junit.AssumptionViolatedException"
 
 if [ $? -eq 0 ]; then
-    echo "\n🔥 Instrumentation test execution failed! Aborting\n"
-    exit 1
-fi
-
-cat instrumentation-outputs/adb-test.log | grep "INSTRUMENTATION_STATUS: stack=" | grep -v "org.junit.AssumptionViolatedException"
-if [ $? -eq 0 ]; then
-  echo "Test failure found"
+  echo "\n🔥 Instrumentation test execution failed! Aborting\n"
   exit 1
 fi
 
 echo "\n🔥 Instrumentation tests ran with success!\n"
-exit 0

--- a/scripts/espresso-run.sh
+++ b/scripts/espresso-run.sh
@@ -4,17 +4,17 @@ set -e
 
 cd ..
 
-echo "🔥 Install the apks...\n"
+echo "\n🔥 Install the apks...\n"
 find  . -name "*.apk" -print -exec adb install {} \;
 
 echo "\n🔥 Running instrumentation"
 
 mkdir instrumentation-outputs
 
-adb logcat -d | tee instrumentation-outputs/logcat.txt &
+adb logcat -d &
 
 RUNNER="io.dotanuki.demos.norris.test/androidx.test.runner.AndroidJUnitRunner"
-adb shell am instrument -w $RUNNER | grep "INSTRUMENTATION_STATUS: stack=" | grep -v "org.junit.AssumptionViolatedException"
+adb shell am instrument -w $RUNNER | grep "FAILURES"
 
 if [ $? -eq 0 ]; then
   echo "\n🔥 Instrumentation test execution failed! Aborting\n"

--- a/scripts/espresso-run.sh
+++ b/scripts/espresso-run.sh
@@ -13,11 +13,11 @@ EXECUTION=`adb shell am instrument -w io.dotanuki.demos.norris.test/androidx.tes
 
 ERRORS_FOUND=`echo $EXECUTION | grep FAILURES`
 
-if [[ -z "$ERRORS_FOUND" ]]; then
-  echo "\n🔥 Instrumentation tests ran with success!\n"
-  exit 0
+if [[ $ERRORS_FOUND ]]; then
+	echo "\n🔥 Instrumentation test execution failed!\n"
+	echo $EXECUTION
+	exit 1
 fi
 
-echo "\n🔥 Instrumentation test execution failed!\n"
-echo $EXECUTION
-exit 1
+echo "\n🔥 Instrumentation tests ran with success!\n"
+exit 0

--- a/scripts/espresso-run.sh
+++ b/scripts/espresso-run.sh
@@ -13,7 +13,7 @@ EXECUTION=`adb shell am instrument -w io.dotanuki.demos.norris.test/androidx.tes
 
 ERRORS_FOUND=`echo $EXECUTION | grep FAILURES`
 
-if [[ $ERRORS_FOUND ]]; then
+if [[ -n "$ERRORS_FOUND" ]]; then
 	echo "\n🔥 Instrumentation test execution failed!\n"
 	echo $EXECUTION
 	exit 1

--- a/scripts/espresso-run.sh
+++ b/scripts/espresso-run.sh
@@ -1,6 +1,6 @@
-#! /bin/sh
+#! /bin/bash
 
-set -e
+set -ex
 
 cd ..
 
@@ -15,10 +15,11 @@ echo $EXECUTION
 
 FAILURES=`echo $EXECUTION | grep FAILURES`
 
-if [ ! -z "$FAILURES" ] then
-  echo "\n🔥 Instrumentation test execution failed!\n"
-  more execution.log
-  exit 1
+if [ -z "$FAILURES" ] then
+  echo "\n🔥 Instrumentation tests ran with success!\n"
+  exit 0
 fi
 
-echo "\n🔥 Instrumentation tests ran with success!\n"
+echo "\n🔥 Instrumentation test execution failed!\n"
+exit 1
+

--- a/scripts/espresso-run.sh
+++ b/scripts/espresso-run.sh
@@ -11,15 +11,13 @@ echo "\n🔥 Running instrumentation"
 
 EXECUTION=`adb shell am instrument -w io.dotanuki.demos.norris.test/androidx.test.runner.AndroidJUnitRunner`
 
-echo $EXECUTION
+ERRORS_FOUND=`echo $EXECUTION | grep FAILURES`
 
-FAILURES=`echo $EXECUTION | grep FAILURES`
-
-if [ -z "$FAILURES" ] then
+if [[ -z "$ERRORS_FOUND" ]]; then
   echo "\n🔥 Instrumentation tests ran with success!\n"
   exit 0
 fi
 
 echo "\n🔥 Instrumentation test execution failed!\n"
+echo $EXECUTION
 exit 1
-

--- a/scripts/espresso-run.sh
+++ b/scripts/espresso-run.sh
@@ -9,6 +9,7 @@ find  . -name "*.apk" -print -exec adb install {} \;
 
 echo "\n🔥 Running instrumentation"
 
+adb logcat &
 adb shell 'am instrument -w io.dotanuki.demos.norris.test/androidx.test.runner.AndroidJUnitRunner; echo $?' | grep 'FAILURES'
 
 if [ $? -eq 0 ;] then

--- a/scripts/espresso-run.sh
+++ b/scripts/espresso-run.sh
@@ -11,7 +11,7 @@ echo "\n🔥 Running instrumentation"
 
 adb shell 'am instrument -w io.dotanuki.demos.norris.test/androidx.test.runner.AndroidJUnitRunner; echo $?' | grep 'FAILURES'
 
-if [ $? -eq 0 ]; then
+if [ $? -eq 0 ;] then
   echo "\n🔥 Instrumentation test execution failed! Aborting\n"
   exit 1
 fi

--- a/scripts/espresso-run.sh
+++ b/scripts/espresso-run.sh
@@ -10,14 +10,14 @@ find  . -name "*.apk" -print -exec adb install {} \;
 echo "\n🔥 Running instrumentation"
 
 TEST_RUNNER="io.dotanuki.demos.norris.test/androidx.test.runner.AndroidJUnitRunner"
-adb shell am instrument -w $TEST_RUNNER > execution.log
+adb shell am instrument -w $TEST_RUNNER
 
-FAILURES=`cat execution.log | grep FAILURES`
+# FAILURES=`cat execution.log | grep FAILURES`
 
-if [ ! -z "$FAILURES" ] then
-  echo "\n🔥 Instrumentation test execution failed!\n"
-  more execution.log
-  exit 1
-fi
+# if [ ! -z "$FAILURES" ] then
+#   echo "\n🔥 Instrumentation test execution failed!\n"
+#   more execution.log
+#   exit 1
+# fi
 
 echo "\n🔥 Instrumentation tests ran with success!\n"

--- a/scripts/espresso-run.sh
+++ b/scripts/espresso-run.sh
@@ -8,15 +8,20 @@ echo "🔥 Install the apks...\n"
 find  . -name "*.apk" -print -exec adb install {} \;
 
 echo "\n🔥 Running instrumentation"
+
+mkdir instrumentation-outputs
+
+adb logcat -d | grep 'norris' | tee instrumentation-outputs/log.txt &
+
 RUNNER="io.dotanuki.demos.norris.test/androidx.test.runner.AndroidJUnitRunner"
-adb shell am instrument -w -r $RUNNER > adb-test.log
+adb shell am instrument -w -r $RUNNER > instrumentation-outputs/adb-test.log
 
 if [ $? -eq 0 ]; then
     echo "\n🔥 Instrumentation test execution failed! Aborting\n"
     exit 1
 fi
 
-cat adb-test.log | grep "INSTRUMENTATION_STATUS: stack=" | grep -v "org.junit.AssumptionViolatedException"
+cat instrumentation-outputs/adb-test.log | grep "INSTRUMENTATION_STATUS: stack=" | grep -v "org.junit.AssumptionViolatedException"
 if [ $? -eq 0 ]; then
   echo "Test failure found"
   exit 1

--- a/scripts/espresso-run.sh
+++ b/scripts/espresso-run.sh
@@ -9,10 +9,8 @@ find  . -name "*.apk" -print -exec adb install {} \;
 
 echo "\n🔥 Running instrumentation"
 
-adb logcat -d &
-
 RUNNER="io.dotanuki.demos.norris.test/androidx.test.runner.AndroidJUnitRunner"
-adb shell "am instrument -w $RUNNER; echo $?" | grep "FAILURES"
+adb shell 'am instrument -w $RUNNER; echo $?' | grep 'FAILURES'
 
 if [ $? -eq 0 ]; then
   echo "\n🔥 Instrumentation test execution failed! Aborting\n"


### PR DESCRIPTION
## Description
Fixing execution since we did not have the exit code from `adb shell` command.

## Motivation and Context
Running the Espresso tests in several emulators (in parallel) at once

## Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Implementation details

We capture the execution from `adb shell` in a variable and grep it. Also we fix a bug where `acceptance_tests` must wait for `espresso_prepare` job to complete.

Last but not least, we use only `Java7` version of assertions for `assertj` in order to avoid compatibility issues with older versions of Android emulators.
