### PR TITLE
Bump kotlinx.serialization to 1.0.1

### DIFF
--- a/buildSrc/src/main/kotlin/Libraries.kt
+++ b/buildSrc/src/main/kotlin/Libraries.kt
@@ -46,7 +46,7 @@ object Libraries {
     const val mockWebServer = "com.squareup.okhttp3:mockwebserver:${Versions.okHttp}"
 
     private object Versions {
-        const val kotlinSerialization = "1.0.0"
+        const val kotlinSerialization = "1.0.1"
         const val okHttp = "4.8.1"
         const val retrofit = "2.9.0"
         const val retrofitKotlinSerialization = "0.8.0"


### PR DESCRIPTION
## Description
Bumps **kotlinx.serialization** to `1.0.1`

## Motivation and Context
https://github.com/Kotlin/kotlinx.serialization/releases/tag/v1.0.1