### PR TITLE
Bump OkHttp to 4.9.0

### DIFF
--- a/buildSrc/src/main/kotlin/Libraries.kt
+++ b/buildSrc/src/main/kotlin/Libraries.kt
@@ -47,7 +47,7 @@ object Libraries {
 
     private object Versions {
         const val kotlinSerialization = "1.0.1"
-        const val okHttp = "4.8.1"
+        const val okHttp = "4.9.0"
         const val retrofit = "2.9.0"
         const val retrofitKotlinSerialization = "0.8.0"
         const val coroutines = "1.3.9"


### PR DESCRIPTION
## Description
Bumps OkHttp to `4.9.0`

## Motivation and Context
https://github.com/square/okhttp/blob/master/CHANGELOG.md#version-490

## Types of changes

- [x] House cleaning (small change at project level)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Implementation details
N/A