### PR TITLE
Bumps TestLogger plugin to 2.1.1

### DIFF
--- a/buildSrc/src/main/kotlin/BuildPlugins.kt
+++ b/buildSrc/src/main/kotlin/BuildPlugins.kt
@@ -30,7 +30,7 @@ object BuildPlugins {
 
     object Versions {
         const val agp = "4.0.1"
-        const val testLogger = "2.1.0"
+        const val testLogger = "2.1.1"
         const val ktlint = "9.4.0"
         const val detekt = "1.14.2"
         const val jacocoUnified = "0.16.0"


### PR DESCRIPTION
## Description
Bumps TestLogger plugin to `2.2.1`

## Motivation and Context
https://github.com/radarsh/gradle-test-logger-plugin/releases/tag/v2.1.1

## Types of changes

- [x] House cleaning (small change at project level)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Implementation details
N/A