### PR TITLE
Bumps Kotlin to 1.4.20

### DIFF
--- a/buildSrc/build.gradle.kts
+++ b/buildSrc/build.gradle.kts
@@ -21,7 +21,7 @@ buildscript {
 dependencies {
     implementation("com.android.tools.build:gradle:4.0.1")
     implementation("com.adarshr:gradle-test-logger-plugin:2.1.0")
-    implementation("org.jetbrains.kotlin:kotlin-gradle-plugin:1.4.10")
+    implementation("org.jetbrains.kotlin:kotlin-gradle-plugin:1.4.20")
     implementation(kotlin("stdlib-jdk8"))
     implementation(kotlin("android-extensions"))
 }

--- a/buildSrc/src/main/kotlin/configs/KotlinConfig.kt
+++ b/buildSrc/src/main/kotlin/configs/KotlinConfig.kt
@@ -1,5 +1,5 @@
 package configs
 object KotlinConfig {
-    const val version = "1.4.10"
+    const val version = "1.4.20"
     const val targetJVM = "1.8"
 }


### PR DESCRIPTION
## Description
Bumps Kotlin to 1.4.20

## Motivation and Context
https://github.com/JetBrains/kotlin/releases/tag/v1.4.20

## Types of changes

- [x] House cleaning (small change at project level)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Implementation details
N/A
