### PR TITLE
Expands build matrix with more SDK levels

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -165,7 +165,7 @@ jobs:
     strategy:
       fail-fast: true
       matrix:
-        android_sdk: [25, 28, 29]
+        android_sdk: [25, 26, 27, 28, 29]
 
     runs-on: macOS-latest
     needs: [assemble_apk, espresso_prepare, unit_tests, static_analysis]
@@ -174,9 +174,10 @@ jobs:
       - name: Project Checkout
         uses: actions/checkout@v2.3.4
 
-      - uses: actions/download-artifact@v2.0.8
+      - name: Fetch Instrumentation artefacts
+        uses: actions/download-artifact@v2.0.8
 
-      - name: Run instrumentation tests
+      - name: Run Instrumentation tests
         uses: reactivecircus/android-emulator-runner@v2.15.0
         with:
           api-level: ${{ matrix.android_sdk }}


### PR DESCRIPTION
## Description
- Adds SDK levels `26` and `27` in the matrix that spawns Instrumentation tests

## Types of changes

- [ ] House cleaning (change at project level, like tooling revamp, refactors, etc)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] Enhancement (non-breaking change which improves existing functionality)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (something that would cause existing functionality to not work as expected)
- [ ] Documentation (self-explained)

## Implementation details
N/A