### PR TITLE
Bump Turbine to 0.4.1

### DIFF
--- a/buildSrc/build.gradle.kts
+++ b/buildSrc/build.gradle.kts
@@ -20,8 +20,8 @@ buildscript {
 
 dependencies {
     implementation("com.android.tools.build:gradle:4.0.1")
-    implementation("com.adarshr:gradle-test-logger-plugin:2.1.0")
-    implementation("org.jetbrains.kotlin:kotlin-gradle-plugin:1.4.20")
+    implementation("com.adarshr:gradle-test-logger-plugin:2.1.1")
+    implementation("org.jetbrains.kotlin:kotlin-gradle-plugin:1.4.32")
     implementation(kotlin("stdlib-jdk8"))
     implementation(kotlin("android-extensions"))
 }

--- a/buildSrc/src/main/kotlin/BuildPlugins.kt
+++ b/buildSrc/src/main/kotlin/BuildPlugins.kt
@@ -1,5 +1,3 @@
-import configs.KotlinConfig
-
 object BuildPlugins {
 
     object Ids {
@@ -8,7 +6,6 @@ object BuildPlugins {
         const val kotlinJVM = "kotlin"
         const val kotlinxSerialization = "org.jetbrains.kotlin.plugin.serialization"
         const val kotlinAndroid = "kotlin-android"
-        const val kotlinAndroidExtensions = "kotlin-android-extensions"
         const val jacocoUnified = "com.vanniktech.android.junit.jacoco"
         const val ktlint = "org.jlleitschuh.gradle.ktlint"
         const val detekt = "io.gitlab.arturbosch.detekt"

--- a/buildSrc/src/main/kotlin/plugins/KotlinTasksConfiguration.kt
+++ b/buildSrc/src/main/kotlin/plugins/KotlinTasksConfiguration.kt
@@ -8,5 +8,8 @@ import org.jetbrains.kotlin.gradle.tasks.KotlinCompile
 fun Project.configureKotlinTasks() {
     tasks.withType<KotlinCompile> {
         kotlinOptions.jvmTarget = KotlinConfig.targetJVM
+        kotlinOptions.freeCompilerArgs += listOf(
+            "-Xopt-in=kotlin.time.ExperimentalTime"
+        )
     }
 }

--- a/features/facts/build.gradle.kts
+++ b/features/facts/build.gradle.kts
@@ -30,5 +30,5 @@ dependencies {
     testImplementation("junit:junit:4.13")
     testImplementation("org.assertj:assertj-core:3.16.1")
     testImplementation("com.github.ubiratansoares:burster:0.1.1")
-    testImplementation("app.cash.turbine:turbine:0.2.1")
+    testImplementation("app.cash.turbine:turbine:0.4.1")
 }

--- a/features/facts/src/test/java/io/dotanuki/norri/facts/FactsViewModelTests.kt
+++ b/features/facts/src/test/java/io/dotanuki/norri/facts/FactsViewModelTests.kt
@@ -17,13 +17,11 @@ import io.dotanuki.norris.facts.FactsScreenState.Loading
 import io.dotanuki.norris.facts.FactsScreenState.Success
 import io.dotanuki.norris.facts.FactsUserInteraction.OpenedScreen
 import io.dotanuki.norris.facts.FactsViewModel
-import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.runBlocking
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.Before
 import org.junit.Rule
 import org.junit.Test
-import kotlin.time.ExperimentalTime
 
 class FactsViewModelTests {
 
@@ -75,8 +73,6 @@ class FactsViewModelTests {
         viewModel = FactsViewModel(fetchFacts, manageQuery)
     }
 
-    @ExperimentalTime
-    @ExperimentalCoroutinesApi
     @Test fun `should report failure when fetching from remote`() {
         runBlocking {
 
@@ -94,13 +90,12 @@ class FactsViewModelTests {
                     )
 
                     assertThat(emissions).isEqualTo(viewStates)
+                    cancelAndIgnoreRemainingEvents()
                 }
             }
         }
     }
 
-    @ExperimentalTime
-    @ExperimentalCoroutinesApi
     @Test fun `should fetch facts from remote data source with success`() {
         runBlocking {
             viewModel.run {
@@ -127,6 +122,7 @@ class FactsViewModelTests {
                     )
 
                     assertThat(emissions).isEqualTo(viewStates)
+                    cancelAndIgnoreRemainingEvents()
                 }
             }
         }

--- a/features/onboarding/build.gradle.kts
+++ b/features/onboarding/build.gradle.kts
@@ -24,5 +24,5 @@ dependencies {
     testImplementation(project(":platform:coroutines-testutils"))
     testImplementation("junit:junit:4.13")
     testImplementation("org.assertj:assertj-core:3.16.1")
-    testImplementation("app.cash.turbine:turbine:0.2.1")
+    testImplementation("app.cash.turbine:turbine:0.4.1")
 }

--- a/features/onboarding/src/test/java/io/dotanuki/norris/onboarding/OnboardingViewModelTests.kt
+++ b/features/onboarding/src/test/java/io/dotanuki/norris/onboarding/OnboardingViewModelTests.kt
@@ -10,13 +10,11 @@ import io.dotanuki.norris.domain.services.RemoteFactsService
 import io.dotanuki.norris.onboarding.OnboardingScreenState.Idle
 import io.dotanuki.norris.onboarding.OnboardingScreenState.Launching
 import io.dotanuki.norris.onboarding.OnboardingScreenState.Success
-import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.runBlocking
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.Before
 import org.junit.Rule
 import org.junit.Test
-import kotlin.time.ExperimentalTime
 
 class OnboardingViewModelTests {
 
@@ -47,8 +45,6 @@ class OnboardingViewModelTests {
         viewModel = OnboardingViewModel(usecase)
     }
 
-    @ExperimentalTime
-    @ExperimentalCoroutinesApi
     @Test fun `should fetch categories when opening screen`() {
         runBlocking {
             viewModel.run {
@@ -59,6 +55,7 @@ class OnboardingViewModelTests {
 
                     val receivedStates = listOf(expectItem(), expectItem(), expectItem())
                     assertThat(receivedStates).isEqualTo(expectedStates)
+                    cancelAndIgnoreRemainingEvents()
                 }
             }
         }

--- a/features/search/build.gradle.kts
+++ b/features/search/build.gradle.kts
@@ -24,5 +24,5 @@ dependencies {
     testImplementation(project(":platform:coroutines-testutils"))
     testImplementation("junit:junit:4.13")
     testImplementation("org.assertj:assertj-core:3.16.1")
-    testImplementation("app.cash.turbine:turbine:0.2.1")
+    testImplementation("app.cash.turbine:turbine:0.4.1")
 }

--- a/features/search/src/test/java/io/dotanuki/norris/search/tests/SearchViewModelTests.kt
+++ b/features/search/src/test/java/io/dotanuki/norris/search/tests/SearchViewModelTests.kt
@@ -14,13 +14,11 @@ import io.dotanuki.norris.search.SearchScreenState.Recommendations
 import io.dotanuki.norris.search.SearchScreenState.SearchHistory
 import io.dotanuki.norris.search.SearchScreenState.SearchQuery
 import io.dotanuki.norris.search.SearchViewModel
-import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.runBlocking
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.Before
 import org.junit.Rule
 import org.junit.Test
-import kotlin.time.ExperimentalTime
 
 class SearchViewModelTests {
 
@@ -59,8 +57,6 @@ class SearchViewModelTests {
         viewModel = SearchViewModel(FakeSearchesHistoryService, fetchCategories)
     }
 
-    @ExperimentalTime
-    @ExperimentalCoroutinesApi
     @Test fun `should display suggestions`() {
         runBlocking {
             viewModel.run {
@@ -81,13 +77,12 @@ class SearchViewModelTests {
 
                     val collectedStates = expectedStates.map { expectItem() }
                     assertThat(collectedStates).isEqualTo(expectedStates)
+                    cancelAndIgnoreRemainingEvents()
                 }
             }
         }
     }
 
-    @ExperimentalTime
-    @ExperimentalCoroutinesApi
     @Test fun `should validate incoming query`() {
         runBlocking {
             viewModel.run {
@@ -100,6 +95,7 @@ class SearchViewModelTests {
 
                     val collectedStates = expectedStates.map { expectItem() }
                     assertThat(collectedStates).isEqualTo(expectedStates)
+                    cancelAndIgnoreRemainingEvents()
                 }
             }
         }


### PR DESCRIPTION
## Description
Self-explained. Fixes #87 

## Types of changes

- [x] House cleaning (change at project level, like tooling revamp, refactors, etc)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Enhancement (non-breaking change which improves existing functionality)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (something that would cause existing functionality to not work as expected)
- [ ] Documentation (self-explained)

## Implementation details
Issue happened because Dependabot did not bump Kotlin for `buildSrc/build.gradle.kts` apparently. So the Kotlin version used by the shared plugin was different than the one required to compile.
