### PR TITLE
[gradle-auto-bumps] Bumps Gradle from 6.8.3 to 7.0

### DIFF
--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,5 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-6.8.3-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-7.0-bin.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists


### PR DESCRIPTION
Upgrade Gradle from `6.8.3` to `7.0`

Release notes: https://docs.gradle.org/7.0/release-notes.html
Reference checksums : https://gradle.org/release-checksums/
