### PR TITLE
Bumping Kotlin and Coroutines to 1.5.0

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -101,7 +101,7 @@ dependencies {
     implementation(project(":features:facts"))
     implementation(project(":features:search"))
 
-    implementation("org.jetbrains.kotlin:kotlin-stdlib-jdk8:1.4.32")
+    implementation("org.jetbrains.kotlin:kotlin-stdlib-jdk8:1.5.0")
     implementation("androidx.appcompat:appcompat:1.2.0")
     implementation("androidx.swiperefreshlayout:swiperefreshlayout:1.1.0")
     implementation("androidx.core:core-ktx:1.3.2")

--- a/features/facts/build.gradle.kts
+++ b/features/facts/build.gradle.kts
@@ -11,11 +11,11 @@ dependencies {
     implementation(project(":platform:shared-utilities"))
     implementation(project(":platform:navigator"))
 
-    implementation("org.jetbrains.kotlin:kotlin-stdlib-jdk8:1.4.32")
+    implementation("org.jetbrains.kotlin:kotlin-stdlib-jdk8:1.5.0")
     implementation("org.kodein.di:kodein-di-jvm:7.5.0")
 
-    implementation("org.jetbrains.kotlinx:kotlinx-coroutines-core:1.4.3")
-    implementation("org.jetbrains.kotlinx:kotlinx-coroutines-android:1.4.3")
+    implementation("org.jetbrains.kotlinx:kotlinx-coroutines-core:1.5.0")
+    implementation("org.jetbrains.kotlinx:kotlinx-coroutines-android:1.5.0")
     implementation("androidx.lifecycle:lifecycle-extensions:2.2.0")
     implementation("androidx.lifecycle:lifecycle-runtime-ktx:2.3.1")
     implementation("androidx.lifecycle:lifecycle-viewmodel-ktx:2.3.1")
@@ -30,5 +30,5 @@ dependencies {
     testImplementation("junit:junit:4.13.2")
     testImplementation("org.assertj:assertj-core:3.16.1")
     testImplementation("com.github.ubiratansoares:burster:0.1.1")
-    testImplementation("app.cash.turbine:turbine:0.4.1")
+    testImplementation("app.cash.turbine:turbine:0.5.0")
 }

--- a/features/onboarding/build.gradle.kts
+++ b/features/onboarding/build.gradle.kts
@@ -10,10 +10,10 @@ dependencies {
     implementation(project(":platform:shared-utilities"))
     implementation(project(":platform:navigator"))
 
-    implementation("org.jetbrains.kotlin:kotlin-stdlib-jdk8:1.4.32")
+    implementation("org.jetbrains.kotlin:kotlin-stdlib-jdk8:1.5.0")
     implementation("org.kodein.di:kodein-di-jvm:7.5.0")
-    implementation("org.jetbrains.kotlinx:kotlinx-coroutines-core:1.4.3")
-    implementation("org.jetbrains.kotlinx:kotlinx-coroutines-android:1.4.3")
+    implementation("org.jetbrains.kotlinx:kotlinx-coroutines-core:1.5.0")
+    implementation("org.jetbrains.kotlinx:kotlinx-coroutines-android:1.5.0")
     implementation("androidx.lifecycle:lifecycle-extensions:2.2.0")
     implementation("androidx.lifecycle:lifecycle-runtime-ktx:2.3.1")
     implementation("androidx.lifecycle:lifecycle-viewmodel-ktx:2.3.1")
@@ -24,5 +24,5 @@ dependencies {
     testImplementation(project(":platform:coroutines-testutils"))
     testImplementation("junit:junit:4.13.2")
     testImplementation("org.assertj:assertj-core:3.16.1")
-    testImplementation("app.cash.turbine:turbine:0.4.1")
+    testImplementation("app.cash.turbine:turbine:0.5.0")
 }

--- a/features/search/build.gradle.kts
+++ b/features/search/build.gradle.kts
@@ -9,10 +9,10 @@ dependencies {
     implementation(project(":platform:shared-assets"))
     implementation(project(":platform:shared-utilities"))
 
-    implementation("org.jetbrains.kotlin:kotlin-stdlib-jdk8:1.4.32")
+    implementation("org.jetbrains.kotlin:kotlin-stdlib-jdk8:1.5.0")
     implementation("org.kodein.di:kodein-di-jvm:7.5.0")
-    implementation("org.jetbrains.kotlinx:kotlinx-coroutines-core:1.4.3")
-    implementation("org.jetbrains.kotlinx:kotlinx-coroutines-android:1.4.3")
+    implementation("org.jetbrains.kotlinx:kotlinx-coroutines-core:1.5.0")
+    implementation("org.jetbrains.kotlinx:kotlinx-coroutines-android:1.5.0")
     implementation("androidx.lifecycle:lifecycle-extensions:2.2.0")
     implementation("androidx.lifecycle:lifecycle-runtime-ktx:2.3.1")
     implementation("androidx.lifecycle:lifecycle-viewmodel-ktx:2.3.1")
@@ -24,5 +24,5 @@ dependencies {
     testImplementation(project(":platform:coroutines-testutils"))
     testImplementation("junit:junit:4.13.2")
     testImplementation("org.assertj:assertj-core:3.16.1")
-    testImplementation("app.cash.turbine:turbine:0.4.1")
+    testImplementation("app.cash.turbine:turbine:0.5.0")
 }

--- a/platform/coroutines-testutils/build.gradle.kts
+++ b/platform/coroutines-testutils/build.gradle.kts
@@ -4,8 +4,8 @@ plugins {
 }
 
 dependencies {
-    implementation("org.jetbrains.kotlin:kotlin-stdlib-jdk8:1.4.32")
-    implementation("org.jetbrains.kotlinx:kotlinx-coroutines-core:1.4.3")
+    implementation("org.jetbrains.kotlin:kotlin-stdlib-jdk8:1.5.0")
+    implementation("org.jetbrains.kotlinx:kotlinx-coroutines-core:1.5.0")
     implementation("org.jetbrains.kotlinx:kotlinx-coroutines-test:1.4.3")
     implementation("org.jetbrains.kotlinx:kotlinx-coroutines-debug:1.4.3")
     implementation("junit:junit:4.13.2")

--- a/platform/domain/build.gradle.kts
+++ b/platform/domain/build.gradle.kts
@@ -4,8 +4,8 @@ plugins {
 }
 
 dependencies {
-    implementation("org.jetbrains.kotlin:kotlin-stdlib-jdk8:1.4.32")
-    implementation("org.jetbrains.kotlinx:kotlinx-coroutines-core:1.4.3")
+    implementation("org.jetbrains.kotlin:kotlin-stdlib-jdk8:1.5.0")
+    implementation("org.jetbrains.kotlinx:kotlinx-coroutines-core:1.5.0")
 
     testImplementation(project(":platform:coroutines-testutils"))
     testImplementation("junit:junit:4.13.2")

--- a/platform/logger/build.gradle.kts
+++ b/platform/logger/build.gradle.kts
@@ -4,5 +4,5 @@ plugins {
 }
 
 dependencies {
-    implementation("org.jetbrains.kotlin:kotlin-stdlib-jdk8:1.4.32")
+    implementation("org.jetbrains.kotlin:kotlin-stdlib-jdk8:1.5.0")
 }

--- a/platform/navigator/build.gradle.kts
+++ b/platform/navigator/build.gradle.kts
@@ -7,7 +7,7 @@ dependencies {
 
     implementation(project(":platform:shared-utilities"))
 
-    implementation("org.jetbrains.kotlin:kotlin-stdlib-jdk8:1.4.32")
+    implementation("org.jetbrains.kotlin:kotlin-stdlib-jdk8:1.5.0")
     implementation("androidx.appcompat:appcompat:1.2.0")
     implementation("androidx.activity:activity:1.2.0-beta02")
     implementation("androidx.activity:activity-ktx:1.2.0-beta02")

--- a/platform/networking/build.gradle.kts
+++ b/platform/networking/build.gradle.kts
@@ -7,14 +7,14 @@ dependencies {
     implementation(project(":platform:logger"))
     implementation(project(":platform:domain"))
 
-    implementation("org.jetbrains.kotlin:kotlin-stdlib-jdk8:1.4.32")
+    implementation("org.jetbrains.kotlin:kotlin-stdlib-jdk8:1.5.0")
     implementation("org.jetbrains.kotlinx:kotlinx-serialization-core:1.2.0")
     implementation("org.jetbrains.kotlinx:kotlinx-serialization-json:1.2.1")
     implementation("com.squareup.okhttp3:okhttp:4.9.1")
     implementation("com.squareup.okhttp3:logging-interceptor:4.9.1")
     implementation("com.squareup.retrofit2:retrofit:2.9.0")
     implementation("com.jakewharton.retrofit:retrofit2-kotlinx-serialization-converter:0.8.0")
-    implementation("org.jetbrains.kotlinx:kotlinx-coroutines-core:1.4.3")
+    implementation("org.jetbrains.kotlinx:kotlinx-coroutines-core:1.5.0")
     implementation("org.kodein.di:kodein-di-jvm:7.5.0")
 
     testImplementation(project(":platform:coroutines-testutils"))

--- a/platform/persistance/build.gradle.kts
+++ b/platform/persistance/build.gradle.kts
@@ -6,7 +6,7 @@ plugins {
 dependencies {
 
     implementation(project(":platform:domain"))
-    implementation("org.jetbrains.kotlinx:kotlinx-coroutines-core:1.4.3")
+    implementation("org.jetbrains.kotlinx:kotlinx-coroutines-core:1.5.0")
     implementation("org.kodein.di:kodein-di-jvm:7.5.0")
 
     testImplementation(project(":platform:coroutines-testutils"))

--- a/platform/rest-chucknorris/build.gradle.kts
+++ b/platform/rest-chucknorris/build.gradle.kts
@@ -9,13 +9,13 @@ dependencies {
     implementation(project(":platform:domain"))
     implementation(project(":platform:networking"))
 
-    implementation("org.jetbrains.kotlin:kotlin-stdlib-jdk8:1.4.32")
+    implementation("org.jetbrains.kotlin:kotlin-stdlib-jdk8:1.5.0")
     implementation("com.squareup.okhttp3:okhttp:4.9.1")
     implementation("com.squareup.okhttp3:logging-interceptor:4.9.1")
     implementation("com.squareup.retrofit2:retrofit:2.9.0")
     implementation("org.jetbrains.kotlinx:kotlinx-serialization-core:1.2.0")
     implementation("org.jetbrains.kotlinx:kotlinx-serialization-json:1.2.1")
-    implementation("org.jetbrains.kotlinx:kotlinx-coroutines-core:1.4.3")
+    implementation("org.jetbrains.kotlinx:kotlinx-coroutines-core:1.5.0")
     implementation("org.kodein.di:kodein-di-jvm:7.5.0")
 
     testImplementation(project(":platform:coroutines-testutils"))

--- a/platform/shared-utilities/build.gradle.kts
+++ b/platform/shared-utilities/build.gradle.kts
@@ -4,7 +4,7 @@ plugins {
 }
 
 dependencies {
-    implementation("org.jetbrains.kotlin:kotlin-stdlib-jdk8:1.4.32")
+    implementation("org.jetbrains.kotlin:kotlin-stdlib-jdk8:1.5.0")
     implementation("org.kodein.di:kodein-di-jvm:7.5.0")
     implementation("androidx.appcompat:appcompat:1.2.0")
     implementation("androidx.lifecycle:lifecycle-extensions:2.2.0")


### PR DESCRIPTION
## Description
Self-explained.

Bumping manually because of a breaking change with [kotlinx.coroutines 1.5.0](https://github.com/cashapp/turbine/issues/36)

## Types of changes

- [x] House cleaning (change at project level, like tooling revamp, refactors, etc)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Enhancement (non-breaking change which improves existing functionality)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (something that would cause existing functionality to not work as expected)
- [ ] Documentation (self-explained)
