### PR TITLE
Bumps Gradle distribution from 6.8.3 to 7.1

### DIFF
--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,6 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-6.8.3-bin.zip
+distributionSha256Sum=2debee19271e1b82c6e41137d78e44e6e841035230a1a169ca47fd3fb09ed87b
+distributionUrl=https\://services.gradle.org/distributions/gradle-7.1-bin.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists


### PR DESCRIPTION
🤖 Upgrades Gradle distribution from `6.8.3` to `7.1`

🔥 Release notes: https://docs.gradle.org/7.1/release-notes.html

🔒 We enforced verification of checksums before opening this Pull Request
- sha256 checksum for updated **wrapper**: `33ad4583fd7ee156f533778736fa1b4940bd83b433934d1cc4e9f608e99a6a89`  
- sha256 checksum for updated **distribution**: `2debee19271e1b82c6e41137d78e44e6e841035230a1a169ca47fd3fb09ed87b`
- Reference page: https://gradle.org/release-checksums/

♥️ This automation is proudly provided by [Dotanuki Labs](https://github.com/dotanuki-labs). We love open-source
