### PR TITLE
Bumps Gradle distribution from 7.1 to 7.1.1

### DIFF
--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,6 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-7.1-bin.zip
+distributionSha256Sum=bf8b869948901d422e9bb7d1fa61da6a6e19411baa7ad6ee929073df85d6365d
+distributionUrl=https\://services.gradle.org/distributions/gradle-7.1.1-bin.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists


### PR DESCRIPTION
🤖 Upgrades Gradle distribution from `7.1` to `7.1.1`

🔥 Release notes: https://docs.gradle.org/7.1.1/release-notes.html

🔒 We enforced verification of checksums before opening this Pull Request
- sha256 checksum for updated **wrapper**: `33ad4583fd7ee156f533778736fa1b4940bd83b433934d1cc4e9f608e99a6a89`  
- sha256 checksum for updated **distribution**: `bf8b869948901d422e9bb7d1fa61da6a6e19411baa7ad6ee929073df85d6365d`
- Reference page: https://gradle.org/release-checksums/

♥️ This automation is proudly provided by [Dotanuki Labs](https://github.com/dotanuki-labs). We love open-source
