### PR TITLE
Improves caching with segregation per Job

### DIFF
--- a/.github/actions/setup-android-build/action.yml
+++ b/.github/actions/setup-android-build/action.yml
@@ -12,9 +12,17 @@ runs:
       - name: Setup JDK
         uses: actions/setup-java@v2.3.0
         with:
-          cache: 'gradle'
           distribution: 'adopt'
           java-version: 11
+
+      - name: Setup Cache
+        uses: actions/cache@v2.1.6
+        with:
+          path: |
+            ~/.gradle/caches
+            ~/.gradle/wrapper
+          key: ${{ runner.os }}-${{ github.job }}-${{ hashFiles('**/*.gradle*') }}-${{ hashFiles('**/gradle/wrapper/gradle-wrapper.properties') }}-${{ hashFiles('**/buildSrc/**/*.kt') }}
+          restore-keys: ${{ runner.os }}-${{ github.job }}-
 
       - name: Optimize for Gradle build
         shell: bash


### PR DESCRIPTION
## Description
> Describe your changes in detail
> Why is this change required? What problem does it solve?
> If it fixes an open issue, please put a link to the issue here.

Self-explained

## Types of changes
> What types of changes does your code introduce? Put an `x` in all the boxes that apply:

- [ ] House cleaning
- [ ] Bug fix
- [x] Enhancement
- [ ] Breaking change
- [ ] New feature
- [ ] New release
- [ ] Documentation

## Additional details
> Please, list here some additional details we should be aware of when reviewing your PR.

Reverts to the previous caching approach, instead of sticking with built-in caching provided by `actions/setup-java`. We also nest caching in the `setup-android-build` composite