### PR TITLE
Bumps Gradle distribution from 7.2 to 7.3

### DIFF
--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionSha256Sum=f581709a9c35e9cb92e16f585d2c4bc99b2b1a5f85d2badbd3dc6bff59e1e6dd
-distributionUrl=https\://services.gradle.org/distributions/gradle-7.2-bin.zip
+distributionSha256Sum=de8f52ad49bdc759164f72439a3bf56ddb1589c4cde802d3cec7d6ad0e0ee410
+distributionUrl=https\://services.gradle.org/distributions/gradle-7.3-bin.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists


### PR DESCRIPTION
🤖 Upgrades Gradle distribution from `7.2` to `7.3`

🔥 Release notes: https://docs.gradle.org/7.3/release-notes.html

🔒 We enforced verification of checksums before opening this Pull Request
- sha256 checksum for updated **wrapper**: `33ad4583fd7ee156f533778736fa1b4940bd83b433934d1cc4e9f608e99a6a89`  
- sha256 checksum for updated **distribution**: `de8f52ad49bdc759164f72439a3bf56ddb1589c4cde802d3cec7d6ad0e0ee410`
- Reference page: https://gradle.org/release-checksums/

♥️ This automation is proudly provided by [Dotanuki Labs](https://github.com/dotanuki-labs). We love open-source
