### PR TITLE
Bumps agp to v7.3.0

### DIFF
--- a/features/facts/src/androidTest/AndroidManifest.xml
+++ b/features/facts/src/androidTest/AndroidManifest.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <manifest
     xmlns:android="http://schemas.android.com/apk/res/android"
-    package="io.dotanuki.norris.facts">
+    package="io.dotanuki.norris.facts.test">
 
     <application android:requestLegacyExternalStorage="true">
         <activity

--- a/features/search/src/androidTest/AndroidManifest.xml
+++ b/features/search/src/androidTest/AndroidManifest.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <manifest
     xmlns:android="http://schemas.android.com/apk/res/android"
-    package="io.dotanuki.norris.search">
+    package="io.dotanuki.norris.search.test">
 
     <application android:requestLegacyExternalStorage="true">
         <activity

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,7 +1,7 @@
 [libraries]
 
 # Gradle Plugins
-gradle-android = "com.android.tools.build:gradle:7.2.2"
+gradle-android = "com.android.tools.build:gradle:7.3.0"
 gradle-kotlin = "org.jetbrains.kotlin:kotlin-gradle-plugin:1.7.10"
 gradle-testlogger = "com.adarshr:gradle-test-logger-plugin:3.2.0"
 gradle-keeper= "com.slack.keeper:keeper:0.12.0"


### PR DESCRIPTION
## Description
> Describe your changes in detail
> Why is this change required? What problem does it solve?
> If it fixes an open issue, please put a link to the issue here.

Closes #660 

## Types of changes
> What types of changes does your code introduce? Put an `x` in all the boxes that apply:

- [x] House cleaning
- [ ] Bug fix
- [ ] Enhancement
- [ ] Breaking change
- [ ] New feature
- [ ] New release
- [ ] Documentation

## Additional details
> Please, list here some additional details we should be aware of when reviewing your PR.

Catches a regression (?) regarding namespacing for Android/Test APKs. We should move to oficial [namespace API provided by AGP](https://developer.android.com/studio/build/configure-app-module#set-namespace) in an upcoming PR, since defining the namespace via AndroidManifest is being deprecated