### PR TITLE
Adds memory leak detection driven by instrumentation tests

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -67,10 +67,17 @@ jobs:
         with:
           norris-key: ${{ secrets.NORRIS_CRYPTO_KEY }}
 
-      - name: Assemble production APK
-        run: ./gradlew app:assembleRelease -PtestMode=true
+      - name: Assemble APKs
+        run: ./gradlew app:assembleDebug app:assembleRelease -PtestMode=true
 
-      - name: Archive APK
+      - name: Archive Debug APK
+        if: success()
+        uses: actions/upload-artifact@v3.1.2
+        with:
+            name: debug-apk
+            path: app/build/outputs/apk/debug
+
+      - name: Archive Release APK
         if: success()
         uses: actions/upload-artifact@v3.1.2
         with:
@@ -99,15 +106,14 @@ jobs:
           norris-key: ${{ secrets.NORRIS_CRYPTO_KEY }}
 
       - name: Assemble Instrumentation tests
-        run: |
-          ./gradlew assembleAndroidTest -PtestMode=true
+        run: ./gradlew assembleAndroidTest
 
       - name: Archive Test APK
         uses: actions/upload-artifact@v3.1.2
         with:
           name: test-apks
           path: |
-            app/build/outputs/apk/androidTest/release
+            app/build/outputs/apk/androidTest/debug
             features/**/build/outputs/apk/androidTest/debug
 
   acceptance-tests:
@@ -123,8 +129,8 @@ jobs:
         uses: emulator-wtf/run-tests@v0.0.11
         with:
           api-token: ${{ secrets.EMULATOR_WTF_TOKEN }}
-          app: release-apk/app-release.apk
-          test: test-apks/app/build/outputs/apk/androidTest/release/app-release-androidTest.apk
+          app: debug-apk/app-debug.apk
+          test: test-apks/app/build/outputs/apk/androidTest/debug/app-debug-androidTest.apk
           outputs-dir: emulator-wtf-results
           devices: model=Pixel2,version=31,atd=true
           use-orchestrator: true
@@ -171,7 +177,7 @@ jobs:
         uses: emulator-wtf/run-tests@v0.0.11
         with:
           api-token: ${{ secrets.EMULATOR_WTF_TOKEN }}
-          app: release-apk/app-release.apk
+          app: debug-apk/app-debug.apk
           test: test-apks/features/${{ matrix.feature }}/build/outputs/apk/androidTest/debug/${{ matrix.feature }}-debug-androidTest.apk
           outputs-dir: emulator-wtf-results-${{ matrix.feature }}
           devices: model=Pixel2,version=31

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -38,6 +38,8 @@ dependencies {
     androidTestImplementation(libs.androidx.test.rules)
     androidTestImplementation(libs.square.okhttp.mockwebserver)
     androidTestImplementation(libs.square.radiography)
+    debugImplementation(libs.square.leakcanary.core)
+    androidTestImplementation(libs.square.leakcanary.instrumentation)
 
     androidTestImplementation(libs.adevinta.barista) {
         exclude(group = "org.jetbrains.kotlin")

--- a/app/src/androidTest/java/io/dotanuki/app/NorrisAcceptanceTests.kt
+++ b/app/src/androidTest/java/io/dotanuki/app/NorrisAcceptanceTests.kt
@@ -4,12 +4,16 @@ import androidx.test.ext.junit.runners.AndroidJUnit4
 import com.adevinta.android.barista.interaction.BaristaClickInteractions.clickOn
 import io.dotanuki.features.facts.ui.FactsActivity
 import io.dotanuki.platform.android.testing.persistance.PersistanceHelper
+import leakcanary.DetectLeaksAfterTestSuccess
 import org.junit.Before
+import org.junit.Rule
 import org.junit.Test
 import org.junit.runner.RunWith
 
 @RunWith(AndroidJUnit4::class)
 class NorrisAcceptanceTests {
+
+    @get:Rule val noMemoryLeaks = DetectLeaksAfterTestSuccess()
 
     init {
         PrettyEspressoErrors.install()

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -52,6 +52,8 @@ square-okhttp-logging = "com.squareup.okhttp3:logging-interceptor:4.10.0"
 square-okhttp-mockwebserver = "com.squareup.okhttp3:mockwebserver:4.10.0"
 square-retrofit = "com.squareup.retrofit2:retrofit:2.9.0"
 square-radiography = "com.squareup.radiography:radiography:2.4.1"
+square-leakcanary-core = "com.squareup.leakcanary:leakcanary-android:2.10"
+square-leakcanary-instrumentation = "com.squareup.leakcanary:leakcanary-android-instrumentation:2.10"
 jw-retrofit-kotlinx = "com.jakewharton.retrofit:retrofit2-kotlinx-serialization-converter:0.8.0"
 
 # Other / Testing

--- a/gradle/plugins/src/main/kotlin/io/dotanuki/norris/gradle/modules/conventions/AndroidModuleConventions.kt
+++ b/gradle/plugins/src/main/kotlin/io/dotanuki/norris/gradle/modules/conventions/AndroidModuleConventions.kt
@@ -126,12 +126,6 @@ fun Project.applyAndroidFeatureLibraryConventions() {
     val android = extensions.findByName("android") as ApplicationExtension
 
     android.apply {
-
-        testBuildType = when {
-            isTestMode() -> "release"
-            else -> "debug"
-        }
-
         defaultConfig {
             testInstrumentationRunner = "androidx.test.runner.AndroidJUnitRunner"
             applicationId = "io.dotanuki.norris.android"


### PR DESCRIPTION
## Description
> Describe your changes in detail
> Why is this change required? What problem does it solve?
> If it fixes an open issue, please put a link to the issue here.

Closes #687 

## Types of changes
> What types of changes does your code introduce? Put an `x` in all the boxes that apply:

- [ ] House cleaning
- [ ] Bug fix
- [x] Enhancement
- [ ] Breaking change
- [ ] New feature
- [ ] New release
- [ ] Documentation

## Additional details
> Please, list here some additional details we should be aware of when reviewing your PR.

Re-introduces `leak-canary` by running instrumentation tests entirely over `debug` variants. 

In the past acceptance/Espresso tests were driven over the testable release build, but it is tricky to get this setup working with `leak-canary`, even on top of [keeper-plugin ](https://github.com/slackhq/keeper). In the feature we can re-run such tests instrumenting the `release` build instead
