### PR TITLE
Disables app-size-analysis from CI for now

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -248,7 +248,6 @@ jobs:
   app-size-analysis:
     runs-on: ubuntu-20.04
     timeout-minutes: 25
-    if: ${{ false }}
     needs: assemble-apk
 
     steps:
@@ -259,6 +258,7 @@ jobs:
         uses: ./.github/actions/setup-android-build
 
       - name: Analyse AppBundle size
+        if: ${{ false }}
         run: ./gradlew app:analyzeReleaseBundle
 
       - name: Archive Reports

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -248,6 +248,7 @@ jobs:
   app-size-analysis:
     runs-on: ubuntu-20.04
     timeout-minutes: 25
+    if: ${{ false }}
     needs: assemble-apk
 
     steps:


### PR DESCRIPTION
## Description
> Describe your changes in detail
> Why is this change required? What problem does it solve?
> If it fixes an open issue, please put a link to the issue here.

ruler-plugin is blocking the upgrade to AGP 8.x.y, so we disable it for now

## Types of changes
> What types of changes does your code introduce? Put an `x` in all the boxes that apply:

- [x] House cleaning
- [ ] Bug fix
- [ ] Enhancement
- [ ] Breaking change
- [ ] New feature
- [ ] New release
- [ ] Documentation

## Additional details
> Please, list here some additional details we should be aware of when reviewing your PR.

More details at https://github.com/spotify/ruler/issues/116