### PR TITLE
Improves ktlint setup

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -17,3 +17,5 @@ ktlint_standard_no-empty-first-line-in-method-block = disabled
 ktlint_standard_filename = disabled
 ktlint_standard_import-ordering = disabled
 ktlint_standard_multiline-if-else = disabled
+ktlint_standard_trailing-comma-on-call-site = disabled
+ktlint_standard_trailing-comma-on-declaration-site = disabled

--- a/gradle/plugins/build.gradle.kts
+++ b/gradle/plugins/build.gradle.kts
@@ -45,7 +45,7 @@ tasks.withType<KotlinCompile>().configureEach {
     kotlinOptions.jvmTarget = "11"
     kotlinOptions.freeCompilerArgs += listOf(
         "-opt-in=kotlin.time.ExperimentalTime",
-        "-opt-in=kotlin.RequiresOptIn"
+        "-opt-in=kotlin.RequiresOptIn",
     )
 }
 

--- a/scripts/code-style-kotlin.sh
+++ b/scripts/code-style-kotlin.sh
@@ -17,7 +17,7 @@ run_ktlint() {
     echo "• Checking code formatting"
     echo
 
-    ktlint --reporter=plain?group_by_file --android
+    ktlint --reporter=plain?group_by_file --code-style=android_studio
 
     echo
     echo -e "• No issues found by ${cyan}ktlint${normal}"

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -35,7 +35,7 @@ include(
 
     // Features
     ":features:facts",
-    ":features:search"
+    ":features:search",
 )
 
 enableFeaturePreview("TYPESAFE_PROJECT_ACCESSORS")


### PR DESCRIPTION
## Description
> Describe your changes in detail
> Why is this change required? What problem does it solve?
> If it fixes an open issue, please put a link to the issue here.

Moves from deprecated option

```
ERROR com.pinterest.ktlint.cli.internal.KtlintCommandLine - 
Option '--android' / '-a' is deprecated and replaced with option '--code-style=android_studio'.
Setting '.editorconfig' property 'ktlint_code_style=android_studio' might be a better idea for a 
project that is always to formatted with this code style.
```

## Types of changes
> What types of changes does your code introduce? Put an `x` in all the boxes that apply:

- [x] House cleaning
- [ ] Bug fix
- [ ] Enhancement
- [ ] Breaking change
- [ ] New feature
- [ ] New release
- [ ] Documentation

## Additional details
> Please, list here some additional details we should be aware of when reviewing your PR.

N/A